### PR TITLE
Added custom versions for docker-compose built services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
 #  web:
 #    build: wharf-web
   api:
-    build: wharf-api
+    build:
+      context: wharf-api
+      args:
+        WHARF_API_VERSION: local docker-compose
     ports:
     - "5001:8080"
     environment:
@@ -32,21 +35,30 @@ services:
     - ALLOW_CORS=YES
     - WHARF_INSTANCE=local
   provider-gitlab:
-    build: wharf-provider-gitlab
+    build:
+      context: wharf-provider-gitlab
+      args:
+        WHARF_GITLAB_VERSION: local docker-compose
     ports:
     - "5002:8080"
     environment:
     - WHARF_API_URL=http://api:8080
     - ALLOW_CORS=YES
   provider-github:
-    build: wharf-provider-github
+    build:
+      context: wharf-provider-github
+      args:
+        WHARF_GITHUB_VERSION: local docker-compose
     ports:
     - "5003:8080"
     environment:
     - WHARF_API_URL=http://api:8080
     - ALLOW_CORS=YES
   provider-azuredevops:
-    build: wharf-provider-azuredevops
+    build:
+      context: wharf-provider-azuredevops
+      args:
+        WHARF_AZUREDEVOPS_VERSION: local docker-compose
     ports:
     - "5004:8080"
     environment:


### PR DESCRIPTION
> For Iver employees: WO0000000663753

With the addition of version endpoints in from

- iver-wharf/wharf-api#2
- iver-wharf/wharf-provider-gitlab#4
- iver-wharf/wharf-provider-github#5
- iver-wharf/wharf-provider-azuredevops#3

This adds just a "nice to have" feature that tells you that the APIs were built in local docker compose

## Preview

![Screenshot_2021-05-11_16-41-22](https://user-images.githubusercontent.com/2477952/117834790-be63dc80-b277-11eb-9300-eaa78b815b82.png)
