### PR TITLE
Enforce startup order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,22 +13,15 @@ services:
     ports:
     - "5001:8080"
     environment:
-    - DBHOST=db
-    - DBUSER=postgres
-    - DBPASS=OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
-    - DBPORT=5432
-    - DBNAME=wharf
-    - DBLOG=true
-    - RABBITMQUSER=guest
-    - RABBITMQPASS=guest
-    - RABBITMQHOST=rabbitmq
-    - RABBITMQPORT=5672
-    - RABBITMQVHOST=
-    - RABBITMQNAME=wharf_queue
-    - RABBITMQDISABLESSL=TRUE
-    - RABBITMQCONNATTEMPTS=10
+    - WHARF_DB_DRIVER=postgres
+    - WHARF_DB_NAME=wharf
+    - WHARF_DB_HOST=DB
+    - WHARF_DB_USERNAME=postgres
+    - WHARF_DB_PASSWORD=OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
+    - WHARF_DB_PORT=5432
+    - WHARF_DB_LOG=true
+    - WHARF_HTTP_OIDC_ENABLE=0
     - MOCK_LOCAL_CI_RESPONSE=true
-    - ALLOW_CORS=YES
     - WHARF_INSTANCE=local
     depends_on:
       db:
@@ -69,9 +62,3 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-## Uncomment to enable RabbitMQ
-#  rabbitmq:
-#    image: "rabbitmq:3-management"
-#    ports:
-#      - "5672:5672"
-#      - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+#version: '3'
 services:
   proxy:
     image: traefik:1.7.10-alpine
@@ -30,6 +30,9 @@ services:
     - MOCK_LOCAL_CI_RESPONSE=true
     - ALLOW_CORS=YES
     - WHARF_INSTANCE=local
+    depends_on:
+      db:
+        condition: service_healthy
   provider-gitlab:
     image: quay.io/iver-wharf/wharf-provider-gitlab
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,17 @@ services:
     image: postgres
     restart: always
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
     ports:
-      - 5432:5432
+    - 5432:5432
     volumes:
-      - ./api-postgresql-data:/var/lib/postgresql/data
+    - ./api-postgresql-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 ## Uncomment to enable RabbitMQ
 #  rabbitmq:
 #    image: "rabbitmq:3-management"


### PR DESCRIPTION
### Problem definition
This solves an issue where the database does not fully initalize before the migrations startrunning under the wharf-api execution. This would previously cause the wharf-api to crash. 

### Problem Mitigation and Solution
This could easily be mitigated by restarting the docker compose orchestration, however with this change this restart is now no longer needed because the wharf-api only starts after the postgres DB is finished initializing.

### More  Info
This also explicitly defines the postgres user as postgres. A needless change but one that makes it simple to define the connection specification by just looking at the set password and username rather than having to go to postgres documentation for finding out which the default user is.

This uses a key from the docker-compose v2 yml configuration. However now the marking for which version of docker-compose file being used is optional. I have not yet found any consequences that seem negative to removing the version specification. 