### PR TITLE
Switch from filesystem to docker volume for postgres data mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,10 +59,12 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./api-postgresql-data:/var/lib/postgresql/data
+      - wharf-postgresql-volume:/var/lib/postgresql/data
 ## Uncomment to enable RabbitMQ
 #  rabbitmq:
 #    image: "rabbitmq:3-management"
 #    ports:
 #      - "5672:5672"
 #      - "15672:15672"
+volumes:
+  wharf-postgresql-volume:


### PR DESCRIPTION
This one has not been previously discussed at all but i found this to be a nice touch that cleans up the dev environment a bit.

Instead of storing the postgres data mount point to disk where all kind of bad stuff can happen to it, we can hide it in plain sight. I find keeping the data mount as a docker volume is much cleaner. This gets it away from all the fancy things that happen in a windows environment on occasion. 

Is there any cool reason one might want to keep it in the local filesystem that i dont know of?