### PR TITLE
Updated Traefik to v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   proxy:
-    image: traefik:1.7.10-alpine
+    image: amd64/traefik:v2.5.0
     ports:
     - "5000:8081"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   proxy:
-    image: amd64/traefik:v2.5.0
+    image: amd64/traefik:v2.5
     ports:
     - "5000:8081"
     volumes:

--- a/traefik/rules.toml
+++ b/traefik/rules.toml
@@ -1,60 +1,28 @@
-# rules
-[backends]
-  [backends.web]
-    [backends.web.servers.server1]
+[http.services]
+  [[http.services.web.loadBalancer.servers]]
     url = "http://web:8080"
-    weight = 10
-  [backends.api]
-    [backends.api.servers.server1]
+  [[http.services.api.loadBalancer.servers]]
     url = "http://api:8080"
-    weight = 10
-  [backends.provider-gitlab]
-    [backends.provider-gitlab.servers.server1]
+  [[http.services.provider-gitlab.loadBalancer.servers]]
     url = "http://provider-gitlab:8080"
-    weight = 10
-  [backends.provider-github]
-    [backends.provider-github.servers.server1]
+  [[http.services.provider-github.loadBalancer.servers]]
     url = "http://provider-github:8080"
-    weight = 10
-  [backends.provider-azuredevops]
-    [backends.provider-azuredevops.servers.server1]
+  [[http.services.provider-azuredevops.loadBalancer.servers]]
     url = "http://provider-azuredevops:8080"
-    weight = 10
 
-[frontends]
-  [frontends.web]
-  entryPoints = ["http"]
-  backend = "web"
-  passHostHeader = true
-  [frontends.web.routes]
-    [frontends.web.routes.route0]
-    rule = "PathPrefix:/"
-  [frontends.api]
-  entryPoints = ["http"]
-  backend = "api"
-  passHostHeader = true
-  [frontends.api.routes]
-    [frontends.api.routes.route0]
-    rule = "PathPrefix:/api/"
-  [frontends.provider-gitlab]
-  entryPoints = ["http"]
-  backend = "provider-gitlab"
-  passHostHeader = true
-  [frontends.provider-gitlab.routes]
-    [frontends.provider-gitlab.routes.route0]
-    rule = "PathPrefix:/import/gitlab"
-  [frontends.provider-github]
-  entryPoints = ["http"]
-  backend = "provider-github"
-  passHostHeader = true
-  [frontends.provider-github.routes]
-    [frontends.provider-github.routes.route0]
-    rule = "PathPrefix:/import/github"
-  [frontends.provider-azuredevops]
-  entryPoints = ["http"]
-  backend = "provider-azuredevops"
-  passHostHeader = true
-  [frontends.provider-azuredevops.routes]
-    [frontends.provider-azuredevops.routes.route0]
-    rule = "PathPrefix:/import/azuredevops"
-	
+[http.routers]
+  [http.routers.web]
+    rule = "PathPrefix(`/`)"
+    service = "web"
+  [http.routers.api]
+    rule = "PathPrefix(`/api/`)"
+    service = "api"
+  [http.routers.provider-gitlab]
+    rule = "PathPrefix(`/import/gitlab`)"
+    service = "provider-gitlab"
+  [http.routers.provider-github]
+    rule = "PathPrefix(`/import/github`)"
+    service = "provider-github"
+  [http.routers.provider-azuredevops]
+    rule = "PathPrefix(`/import/azuredevops`)"
+    service = "provider-azuredevops"

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,17 +1,17 @@
-# traefik.toml
-logLevel = "WARNING"
-defaultEntryPoints = ["http"]
 [entryPoints]
   [entryPoints.http]
-  address = ":8081"
+    address = ":8081"
 
-[accessLog]
-  filePath = "/var/log/traefik-access.log"
-  format = "json"
+[providers]
+  [provider.docker]
+    defaultRule = "Host(`{{ trimPrefix `/` .Name }}.docker.localhost`)"
+  [providers.file]
+    watch = true
+    filename = "/etc/traefik/rules.toml"
 
 [api]
+  insecure = true
   dashboard = true
 
-[file]
-  filename = "/etc/traefik/rules.toml"
-  watch = true
+[log]
+  level = "WARNING"


### PR DESCRIPTION
Traefik v1 is quite old and outdated. It got annoying to try and seek out the relevant old and deprecated documentation for Traefik v1, so I updated to Traefik v2.

There were backward incompatible changes in the configs, which I have updated according to this: https://doc.traefik.io/traefik/migration/v1-to-v2/

Some of the configs were also inspired by the examples over at https://github.com/containous/traefik-library-image#traefik-v2---example-usage