### PR TITLE
Added "tty: true" on API services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-env-generic-backend: &x-env-generic-backend
 services:
   proxy:
     image: amd64/traefik:v2.5
+    tty: true
     ports:
     - "5000:8081"
     volumes:
@@ -16,6 +17,7 @@ services:
     image: quay.io/iver-wharf/wharf-web
   api:
     image: quay.io/iver-wharf/wharf-api
+    tty: true
     ports:
     - "5001:8080"
     environment:
@@ -38,18 +40,21 @@ services:
       WHARF_INSTANCE: local
   provider-gitlab:
     image: quay.io/iver-wharf/wharf-provider-gitlab
+    tty: true
     ports:
     - "5002:8080"
     environment:
       <<: *x-env-generic-backend
   provider-github:
     image: quay.io/iver-wharf/wharf-provider-github
+    tty: true
     ports:
     - "5003:8080"
     environment:
       <<: *x-env-generic-backend
   provider-azuredevops:
     image: quay.io/iver-wharf/wharf-provider-azuredevops
+    tty: true
     ports:
     - "5004:8080"
     environment:


### PR DESCRIPTION
Having `tty: true` will enable colors in the console logs for the services that supports it. The logger from wharf-core enables colors once a tty is available.

Only some services supported it, while other didn't. All wharf API images supports it, as well as the traefik proxy. The DB just ended up spewing out more uncessesary logs, and the Wharf web nginx image had do effect.

Before:

![Screenshot from 2021-09-10 09-10-10](https://user-images.githubusercontent.com/2477952/132814683-01bc517b-a608-4562-9095-b39fa41f3725.png)

After:

![Screenshot from 2021-09-10 09-08-55](https://user-images.githubusercontent.com/2477952/132814680-795bcd62-f7c4-4073-a2f7-ae53993cc7d0.png)
