### PR TITLE
Update environment vars to wharf-api v5 form

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -10,8 +10,8 @@ services:
     ## Slight warning that it does take significantly more time to build than
     ## the other services though.
     deploy:
-      replicas: 0
-    #build: wharf-web
+      replicas: 1
+    build: wharf-web
 
   api:
     build:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -10,8 +10,8 @@ services:
     ## Slight warning that it does take significantly more time to build than
     ## the other services though.
     deploy:
-      replicas: 1
-    build: wharf-web
+      replicas: 0
+    #build: wharf-web
 
   api:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,13 @@ services:
     - "5001:8080"
     environment:
       <<: *x-env-generic-backend
-      WHARF_HTTP_DB_DRIVER: postgres
-      WHARF_HTTP_DB_HOST: db
-      WHARF_HTTP_DB_PORT: 5432
-      WHARF_HTTP_DB_USERNAME: postgres
-      WHARF_HTTP_DB_PASSWORD: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
-      WHARF_HTTP_DB_NAME: wharf
-      WHARF_HTTP_DB_LOG: "true"
+      WHARF_DB_DRIVER: postgres
+      WHARF_DB_HOST: db
+      WHARF_DB_PORT: 5432
+      WHARF_DB_USERNAME: postgres
+      WHARF_DB_PASSWORD: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
+      WHARF_DB_NAME: wharf
+      WHARF_DB_LOG: "true"
       MOCK_LOCAL_CI_RESPONSE: "true"
       WHARF_INSTANCE: local
   provider-gitlab:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 x-env-generic-backend: &x-env-generic-backend
   TZ: Europe/Stockholm
   WHARF_API_URL: http://api:8080
-  ALLOW_CORS: "YES"
+  WHARF_HTTP_CORS_ALLOWALLORIGINS: "YES"
 
 services:
   proxy:
@@ -13,8 +13,10 @@ services:
     - "5000:8081"
     volumes:
     - ./wharf-docker-compose/traefik:/etc/traefik # Traefik configuration file
-  web:
-    image: quay.io/iver-wharf/wharf-web
+#  web:
+#    image: w-web:1
+#    ports:
+#    - "8080:8080"
   api:
     image: quay.io/iver-wharf/wharf-api
     tty: true
@@ -22,20 +24,13 @@ services:
     - "5001:8080"
     environment:
       <<: *x-env-generic-backend
-      DBHOST: db
-      DBUSER: postgres
-      DBPASS: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
-      DBPORT: 5432
-      DBNAME: wharf
-      DBLOG: "true"
-      RABBITMQUSER: guest
-      RABBITMQPASS: guest
-      RABBITMQHOST: rabbitmq
-      RABBITMQPORT: 5672
-      RABBITMQVHOST:
-      RABBITMQNAME: wharf_queue
-      RABBITMQDISABLESSL: "true"
-      RABBITMQCONNATTEMPTS: 10
+      WHARF_HTTP_DB_DRIVER: postgres
+      WHARF_HTTP_DB_HOST: db
+      WHARF_HTTP_DB_PORT: 5432
+      WHARF_HTTP_DB_USERNAME: postgres
+      WHARF_HTTP_DB_PASSWORD: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
+      WHARF_HTTP_DB_NAME: wharf
+      WHARF_HTTP_DB_LOG: "true"
       MOCK_LOCAL_CI_RESPONSE: "true"
       WHARF_INSTANCE: local
   provider-gitlab:
@@ -69,11 +64,5 @@ services:
       - "5432:5432"
     volumes:
       - wharf-postgresql-volume:/var/lib/postgresql/data
-## Uncomment to enable RabbitMQ
-#  rabbitmq:
-#    image: "rabbitmq:3-management"
-#    ports:
-#      - "5672:5672"
-#      - "15672:15672"
 volumes:
   wharf-postgresql-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 x-env-generic-backend: &x-env-generic-backend
   TZ: Europe/Stockholm
   WHARF_API_URL: http://api:8080
-  WHARF_HTTP_CORS_ALLOWALLORIGINS: "YES"
+  WHARF_HTTP_CORS_ALLOWALLORIGINS: "true"
 
 services:
   proxy:
@@ -13,10 +13,8 @@ services:
     - "5000:8081"
     volumes:
     - ./wharf-docker-compose/traefik:/etc/traefik # Traefik configuration file
-#  web:
-#    image: w-web:1
-#    ports:
-#    - "8080:8080"
+  web:
+    image: quay.io/iver-wharf/wharf-web
   api:
     image: quay.io/iver-wharf/wharf-api
     tty: true


### PR DESCRIPTION
## Summary

Changes environment variables to follow the form introduced with config files for the v5 wharf-api.

This also adds a variable to set usage of the postgresql drvier. Without this the docker-compose file becomes uncohesive- the database postgres is brought online and used. 

The file here https://github.com/iver-wharf/wharf-api/blob/master/config.go is a good guide for checking the names suggested.

## Motivation

I should make it easier to deduce the alternative options when need comes to change the file for development.
It also allows deprecation of the older form.
